### PR TITLE
Fix collection day move if holiday is in week and after the collectio…

### DIFF
--- a/custom_components/garbage_collection/sensor.py
+++ b/custom_components/garbage_collection/sensor.py
@@ -453,9 +453,8 @@ class GarbageCollection(Entity):
 
             if bool(self.__holiday_in_week_move):
                 start_date = next_date - timedelta(days=next_date.weekday())
-                end_date = start_date + timedelta(days=6)
                 delta = timedelta(days=1)
-                while start_date <= end_date:
+                while start_date <= next_date:
                     if start_date in self.__holidays:
                         _LOGGER.debug(
                             "(%s) Move possible collection day, because public holiday in week on %s",


### PR DESCRIPTION
…n day (#175)

* If a holiday is in the same week as the collection day and
the holiday is after the collection day, it makes no sense to move
the collection day to the following day, as the holiday is already over
on collection day.