### PR TITLE
Remove python built-ins from manifest.json

### DIFF
--- a/custom_components/garbage_collection/manifest.json
+++ b/custom_components/garbage_collection/manifest.json
@@ -9,11 +9,8 @@
     "@bruxy70"
   ],
   "requirements": [
-    "datetime",
     "python-dateutil>=2.8.1",
     "holidays>=0.10.1",
-    "typing",
-    "uuid", 
     "voluptuous"
   ]
 }


### PR DESCRIPTION
Attempting to install typing on Home Assistant 0.115 is
blocked because the typing package breaks the built-in
one on newer python. uuid has a similar restriction.

```
2020-09-03 18:14:13 ERROR (SyncWorker_18) [homeassistant.util.package] Unable to install package typing: ERROR: Could not find a version that satisfies the requirement typing==1000000000.0.0 (from -c /usr/src/homeassistant/homeassistant/package_constraints.txt (line 50)) (from versions: 3.5.0b1, 3.5.0, 3.5.0.1, 3.5.1.0, 3.5.2.2, 3.5.3.0, 3.6.1, 3.6.2, 3.6.4, 3.6.6, 3.7.4, 3.7.4.1, 3.7.4.3)
ERROR: No matching distribution found for typing==1000000000.0.0 (from -c /usr/src/homeassistant/homeassistant/package_constraints.txt (line 50))
WARNING: You are using pip version 20.1.1; however, version 20.2.2 is available.
You should consider upgrading via the '/usr/local/bin/python3 -m pip install --upgrade pip' command.
2020-09-03 18:14:13 ERROR (MainThread) [homeassistant.setup] Setup failed for garbage_collection: Requirements for garbage_collection not found: ['typing'].
```