### PR TITLE
Calendar workaround - partial rollback

### DIFF
--- a/custom_components/garbage_collection/calendar.py
+++ b/custom_components/garbage_collection/calendar.py
@@ -114,13 +114,16 @@ class EntitiesCalendarData:
                     event = {
                         "uid": entity,
                         "summary": garbage_collection.name,
-                        "start": {"date": start.strftime("%Y-%m-%d %H:%M")},
-                        "end": {
-                            "date": datetime.combine(
-                                start, garbage_collection.expire_after
-                            ).strftime("%Y-%m-%d %H:%M")
-                        },
-                        "allDay": False,
+                        "start": {"date": start.strftime("%Y-%m-%d")},
+                        "end": {"date": end.strftime("%Y-%m-%d")},
+                        "allDay": True,
+                        # "start": {"date": start.strftime("%Y-%m-%d %H:%M")},
+                        # "end": {
+                        #     "date": datetime.combine(
+                        #         start, garbage_collection.expire_after
+                        #     ).strftime("%Y-%m-%d %H:%M")
+                        # },
+                        # "allDay": False,
                     }
                 events.append(event)
                 start = await garbage_collection.async_find_next_date(
@@ -155,13 +158,16 @@ class EntitiesCalendarData:
                     event = {
                         "uid": entity,
                         "summary": state_object.attributes.get("friendly_name"),
-                        "start": {"date": start.strftime("%Y-%m-%d %H:%M")},
-                        "end": {
-                            "date": datetime.combine(
-                                start, garbage_collection.expire_after
-                            ).strftime("%Y-%m-%d %H:%M")
-                        },
-                        "allDay": False,
+                        "start": {"date": start.strftime("%Y-%m-%d")},
+                        "end": {"date": end.strftime("%Y-%m-%d")},
+                        "allDay": True,
+                        # "start": {"date": start.strftime("%Y-%m-%d %H:%M")},
+                        # "end": {
+                        #     "date": datetime.combine(
+                        #         start, garbage_collection.expire_after
+                        #     ).strftime("%Y-%m-%d %H:%M")
+                        # },
+                        # "allDay": False,
                     }
                 events.append(event)
         events.sort(key=lambda x: x["start"]["date"])


### PR DESCRIPTION
Looks like the calendar gets confused at the collection if expire_after us defined and it is after this time. This is a partial rollback to the previous functionality (everything is full-day event). But it is still missing that entry from the calendar. But at least it does not fail. I will fix that in the next release.