### PR TITLE
Supporting additional countries

### DIFF
--- a/custom_components/garbage_collection/const.py
+++ b/custom_components/garbage_collection/const.py
@@ -175,6 +175,11 @@ COUNTRY_CODES = [
     "UK",
     "US",
     "ZA",
+    "England",
+    "Wales",
+    "Scotland",
+    "IsleOfMan",
+    "NorthernIreland",
 ]
 
 

--- a/custom_components/garbage_collection/translations/sensor.dk.json
+++ b/custom_components/garbage_collection/translations/sensor.dk.json
@@ -1,0 +1,8 @@
+{
+    "state": {
+        "garbage_collection__schedule": {
+            "today": "i dag",
+            "tomorrow": "i morgen"
+        }
+    }
+}


### PR DESCRIPTION
#234 Added Danish translation
#213 Added distinct holidays for England, IsleOfMan, NorthernIreland, Scotland and Wales.