### PR TITLE
4.0 Version

### DIFF
--- a/Garbage Collection.code-workspace
+++ b/Garbage Collection.code-workspace
@@ -4,5 +4,9 @@
 			"path": "."
 		}
 	],
-	"settings": {}
+	"settings": {
+		"files.associations": {
+			"*.yaml": "home-assistant"
+		}
+	}
 }

--- a/README.md
+++ b/README.md
@@ -133,8 +133,8 @@ Entity_id change is not possible using the YAML configuration. Changing other pa
 |:----------|----------|------------
 | `first_month` | No | Month three letter abbreviation, e.g. `"jan"`, `"feb"`...<br/>**Default**: `"jan"`
 | `last_month` | No | Month three letter abbreviation.<br/>**Default**: `"dec"`
-| `exclude_dates` | No | List of dates with no collection (using international date format `'yyyy-mm-dd'`. 
-| `include_dates` | No | List of extra collection (using international date format `'yyyy-mm-dd'`.
+| `exclude_dates` | No | List of dates with no collection (using international date format `'yyyy-mm-dd'`. Make sure to enter the date in quotes!
+| `include_dates` | No | List of extra collection (using international date format `'yyyy-mm-dd'`. Make sure to enter the date in quotes!
 | `move_country_holidays` | No | Country holidays - the country code (see [holidays](https://github.com/dr-prodigy/python-holidays) for the list of valid country codes).<br/>Automatically move garbage collection on public holidays to the following day.<br/>*Example:* `US` 
 | `holiday_in_week_move` | No | Move garbage collection to the following day if a holiday is in week.<br/>**Default**: `false`
 | `holiday_move_offset` | No | Move the collection by the number of days (integer -7..7) **Default**: 1
@@ -244,7 +244,7 @@ Note that this date will be removed on the next sensor update when data is re-ca
 | Attribute | Description
 |:----------|------------
 | `entity_id` | The garbage collection entity id (e.g. `sensor.general_waste`)
-| `date` | The date to be added, in ISO format (`yyyy-mm-dd`)
+| `date` | The date to be added, in ISO format (`'yyyy-mm-dd'`). Make sure to enter the date in quotes!
 
 ### garbage_collection.remove_date
 Remove a date to the list of dates calculated automatically. To remove multiple dates, call this service multiple times with different dates.
@@ -253,7 +253,7 @@ Note that this date will reappear on the next sensor update when data is re-calc
 | Attribute | Description
 |:----------|------------
 | `entity_id` | The garbage collection entity id (e.g. `sensor.general_waste`)
-| `date` | The date to be removed, in ISO format (`yyyy-mm-dd`)
+| `date` | The date to be removed, in ISO format (`'yyyy-mm-dd'`). Make sure to enter the date in quotes!
 
 ### garbage_collection.update_state
 Choose the next collection date from the list of dates calculated automatically, added by service calls (and not removed), and update the entity state and attributes.

--- a/README.md
+++ b/README.md
@@ -334,7 +334,6 @@ trigger:
     event_type: garbage_collection_loaded
     event_data:
       entity_id: sensor.test
-condition: "{{ trigger.event.data.entity_id == 'sensor.test' }}"
 action:
   - repeat:
       count: '{{ trigger.event.data.collection_dates | count }}'

--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ You will **have to create an automation triggered by this event**. In this autom
 
 ### garbage_collection.add_date
 Add a date to the list of dates calculated automatically. To add multiple dates, call this service multiple times with different dates.
-Note that this date will be removed on next sensor update when data is re-calculated and loaded. This is why this service should be called from the automation triggered be the event `garbage_collection_loaded`, that is called each time the sensor is updated. And at the end of this automation you need to call the `garbage_collection.update_state` service to update the sensor state based on automatically collected dates with the dates added and removed by the automation.
+Note that this date will be removed on the next sensor update when data is re-calculated and loaded. This is why this service should be called from the automation triggered be the event `garbage_collection_loaded`, that is called each time the sensor is updated. And at the end of this automation you need to call the `garbage_collection.update_state` service to update the sensor state based on automatically collected dates with the dates added and removed by the automation.
 
 | Attribute | Description
 |:----------|------------
@@ -248,7 +248,7 @@ Note that this date will be removed on next sensor update when data is re-calcul
 
 ### garbage_collection.remove_date
 Remove a date to the list of dates calculated automatically. To remove multiple dates, call this service multiple times with different dates.
-Note that this date will be removed on next sensor update when data is re-calculated and loaded. This is why this service should be called from the automation triggered be the event `garbage_collection_loaded`, that is called each time the sensor is updated. And at the end of this automation you need to call the `garbage_collection.update_state` service to update the sensor state based on automatically collected dates with the dates added and removed by the automation.
+Note that this date will reappear on the next sensor update when data is re-calculated and loaded. This is why this service should be called from the automation triggered be the event `garbage_collection_loaded`, that is called each time the sensor is updated. And at the end of this automation you need to call the `garbage_collection.update_state` service to update the sensor state based on automatically collected dates with the dates added and removed by the automation.
 
 | Attribute | Description
 |:----------|------------

--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ This is the configuration
         card:
           type: picture-entity
           name_template: >-
-            {{ states.sensor.bio.attributes.days }} days
+            {{ state_attr('sensor.bio','days') }} days
           show_name: True
           show_state: False
           entity: sensor.bio

--- a/README.md
+++ b/README.md
@@ -295,6 +295,32 @@ action:
 mode: single
 ```
 
+## Moderate example
+This will loop through the calculated dates, and add extra collection to a day after each calculated one. So if this is set for a collection each first Wednesday each month, it will result in a collection on first Wednesday, and the following day (kind of first Thursday, except if the week is starting on Thursday - just a random weird example :).
+
+```yaml
+alias: test garbage_collection event
+description: 'Loop through all calculated dates, add extra collection a day after the calculate one'
+trigger:
+  - platform: event
+    event_type: garbage_collection_loaded
+    event_data:
+      entity_id: sensor.test
+action:
+  - repeat:
+      count: '{{ trigger.event.data.collection_dates | count }}'
+      sequence:
+        - service: garbage_collection.add_date
+          data:
+            entity_id: sensor.test
+            date: >-
+              {{( as_datetime(trigger.event.data.collection_dates[repeat.index]) + timedelta( days = 1)) | as_timestamp | timestamp_custom("%Y-%m-%d") }}
+  - service: garbage_collection.update_state
+    data:
+      entity_id: sensor.test
+mode: single
+```
+
 ## Advanced example
 Checking the automatically created collection schedule, comparing with list of public holidays and moving schecule by a custom offset.
 

--- a/custom_components/garbage_collection/__init__.py
+++ b/custom_components/garbage_collection/__init__.py
@@ -64,24 +64,22 @@ async def async_setup(hass, config):
     async def handle_add_date(call):
         """Handle the add_date service call."""
         entity_id = call.data.get(CONF_ENTITY_ID)
-        dt = call.data.get(CONF_DATE)
-        _LOGGER.debug("called add_date %s to %s", dt, entity_id)
+        collection_date = call.data.get(CONF_DATE)
+        _LOGGER.debug("called add_date %s to %s", collection_date, entity_id)
         try:
             entity = hass.data[DOMAIN][SENSOR_PLATFORM][entity_id]
-            _LOGGER.debug("date type is %s", type(dt))
-            # await entity.add_date(dt)
+            await entity.add_date(collection_date)
         except Exception as err:
             _LOGGER.error("Failed adding date for %s - %s", entity_id, err)
 
     async def handle_remove_date(call):
         """Handle the remove_date service call."""
         entity_id = call.data.get(CONF_ENTITY_ID)
-        dt = call.data.get(CONF_DATE)
-        _LOGGER.debug("called remove_date %s to %s", dt, entity_id)
+        collection_date = call.data.get(CONF_DATE)
+        _LOGGER.debug("called remove_date %s to %s", collection_date, entity_id)
         try:
             entity = hass.data[DOMAIN][SENSOR_PLATFORM][entity_id]
-            _LOGGER.debug("date type is %s", type(dt))
-            # await entity.remove_date(dt)
+            await entity.remove_date(collection_date)
         except Exception as err:
             _LOGGER.error("Failed removing date for %s - %s", entity_id, err)
 

--- a/custom_components/garbage_collection/__init__.py
+++ b/custom_components/garbage_collection/__init__.py
@@ -39,20 +39,20 @@ CONFIG_SCHEMA = vol.Schema(
 
 COLLECT_NOW_SCHEMA = vol.Schema(
     {
-        vol.Required(CONF_ENTITY_ID): cv.string,
+        vol.Required(CONF_ENTITY_ID): vol.All(cv.ensure_list, [cv.string]),
         vol.Optional(ATTR_LAST_COLLECTION): cv.datetime,
     }
 )
 
 UPDATE_STATE_SCHEMA = vol.Schema(
     {
-        vol.Required(CONF_ENTITY_ID): cv.string,
+        vol.Required(CONF_ENTITY_ID): vol.All(cv.ensure_list, [cv.string]),
     }
 )
 
 ADD_REMOVE_DATE_SCHEMA = vol.Schema(
     {
-        vol.Required(CONF_ENTITY_ID): cv.string,
+        vol.Required(CONF_ENTITY_ID): vol.All(cv.ensure_list, [cv.string]),
         vol.Required(CONF_DATE): cv.date,
     }
 )
@@ -63,50 +63,52 @@ async def async_setup(hass, config):
 
     async def handle_add_date(call):
         """Handle the add_date service call."""
-        entity_id = call.data.get(CONF_ENTITY_ID)
-        collection_date = call.data.get(CONF_DATE)
-        _LOGGER.debug("called add_date %s to %s", collection_date, entity_id)
-        try:
-            entity = hass.data[DOMAIN][SENSOR_PLATFORM][entity_id]
-            await entity.add_date(collection_date)
-        except Exception as err:
-            _LOGGER.error("Failed adding date for %s - %s", entity_id, err)
+        for entity_id in call.data.get(CONF_ENTITY_ID):
+            collection_date = call.data.get(CONF_DATE)
+            _LOGGER.debug("called add_date %s to %s", collection_date, entity_id)
+            try:
+                entity = hass.data[DOMAIN][SENSOR_PLATFORM][entity_id]
+                await entity.add_date(collection_date)
+            except Exception as err:
+                _LOGGER.error("Failed adding date for %s - %s", entity_id, err)
 
     async def handle_remove_date(call):
         """Handle the remove_date service call."""
-        entity_id = call.data.get(CONF_ENTITY_ID)
-        collection_date = call.data.get(CONF_DATE)
-        _LOGGER.debug("called remove_date %s to %s", collection_date, entity_id)
-        try:
-            entity = hass.data[DOMAIN][SENSOR_PLATFORM][entity_id]
-            await entity.remove_date(collection_date)
-        except Exception as err:
-            _LOGGER.error("Failed removing date for %s - %s", entity_id, err)
+        for entity_id in call.data.get(CONF_ENTITY_ID):
+            collection_date = call.data.get(CONF_DATE)
+            _LOGGER.debug("called remove_date %s to %s", collection_date, entity_id)
+            try:
+                entity = hass.data[DOMAIN][SENSOR_PLATFORM][entity_id]
+                await entity.remove_date(collection_date)
+            except Exception as err:
+                _LOGGER.error("Failed removing date for %s - %s", entity_id, err)
 
     async def handle_update_state(call):
         """Handle the update_state service call."""
-        entity_id = call.data.get(CONF_ENTITY_ID)
-        _LOGGER.debug("called update_state for %s", entity_id)
-        try:
-            entity = hass.data[DOMAIN][SENSOR_PLATFORM][entity_id]
-            await entity.async_update_state()
-        except Exception as err:
-            _LOGGER.error("Failed updating state for %s - %s", entity_id, err)
+        for entity_id in call.data.get(CONF_ENTITY_ID):
+            _LOGGER.debug("called update_state for %s", entity_id)
+            try:
+                entity = hass.data[DOMAIN][SENSOR_PLATFORM][entity_id]
+                await entity.async_update_state()
+            except Exception as err:
+                _LOGGER.error("Failed updating state for %s - %s", entity_id, err)
 
     async def handle_collect_garbage(call):
         """Handle the collect_garbage service call."""
-        entity_id = call.data.get(CONF_ENTITY_ID)
-        last_collection = call.data.get(ATTR_LAST_COLLECTION)
-        _LOGGER.debug("called collect_garbage for %s", entity_id)
-        try:
-            entity = hass.data[DOMAIN][SENSOR_PLATFORM][entity_id]
-            if last_collection is None:
-                entity.last_collection = dt_util.now()
-            else:
-                entity.last_collection = dt_util.as_local(last_collection)
-            await entity.async_update_state()
-        except Exception as err:
-            _LOGGER.error("Failed setting last collection for %s - %s", entity_id, err)
+        for entity_id in call.data.get(CONF_ENTITY_ID):
+            last_collection = call.data.get(ATTR_LAST_COLLECTION)
+            _LOGGER.debug("called collect_garbage for %s", entity_id)
+            try:
+                entity = hass.data[DOMAIN][SENSOR_PLATFORM][entity_id]
+                if last_collection is None:
+                    entity.last_collection = dt_util.now()
+                else:
+                    entity.last_collection = dt_util.as_local(last_collection)
+                await entity.async_update_state()
+            except Exception as err:
+                _LOGGER.error(
+                    "Failed setting last collection for %s - %s", entity_id, err
+                )
 
     if DOMAIN not in hass.services.async_services():
         hass.services.async_register(

--- a/custom_components/garbage_collection/__init__.py
+++ b/custom_components/garbage_collection/__init__.py
@@ -104,9 +104,9 @@ async def async_setup(hass, config):
                 entity.last_collection = dt_util.now()
             else:
                 entity.last_collection = dt_util.as_local(last_collection)
+            await entity.async_update_state()
         except Exception as err:
             _LOGGER.error("Failed setting last collection for %s - %s", entity_id, err)
-        hass.services.call("homeassistant", "update_entity", {"entity_id": entity_id})
 
     if DOMAIN not in hass.services.async_services():
         hass.services.async_register(

--- a/custom_components/garbage_collection/__init__.py
+++ b/custom_components/garbage_collection/__init__.py
@@ -59,7 +59,7 @@ async def async_setup(hass, config):
         _LOGGER.debug("called update_state for %s", entity_id)
         try:
             entity = hass.data[DOMAIN][SENSOR_PLATFORM][entity_id]
-            entity.async_update_state()
+            await entity.async_update_state()
         except Exception as err:
             _LOGGER.error("Failed updating state for %s - %s", entity_id, err)
 

--- a/custom_components/garbage_collection/__init__.py
+++ b/custom_components/garbage_collection/__init__.py
@@ -53,17 +53,17 @@ UPDATE_STATE_SCHEMA = vol.Schema(
 async def async_setup(hass, config):
     """Set up this component using YAML."""
 
-    def handle_update_state(call):
+    async def handle_update_state(call):
         """Handle the update_state service call."""
         entity_id = call.data.get(CONF_ENTITY_ID)
         _LOGGER.debug("called update_state for %s", entity_id)
         try:
             entity = hass.data[DOMAIN][SENSOR_PLATFORM][entity_id]
-            await entity.async_update_state()
+            entity.async_update_state()
         except Exception as err:
             _LOGGER.error("Failed updating state for %s - %s", entity_id, err)
 
-    def handle_collect_garbage(call):
+    async def handle_collect_garbage(call):
         """Handle the collect_garbage service call."""
         entity_id = call.data.get(CONF_ENTITY_ID)
         last_collection = call.data.get(ATTR_LAST_COLLECTION)

--- a/custom_components/garbage_collection/__init__.py
+++ b/custom_components/garbage_collection/__init__.py
@@ -12,6 +12,7 @@ from homeassistant.helpers import discovery
 
 from .const import (
     ATTR_LAST_COLLECTION,
+    CONF_DATE,
     CONF_FREQUENCY,
     CONF_SENSORS,
     DOMAIN,
@@ -49,9 +50,40 @@ UPDATE_STATE_SCHEMA = vol.Schema(
     }
 )
 
+ADD_REMOVE_DATE_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_ENTITY_ID): cv.string,
+        vol.Required(CONF_DATE): cv.date,
+    }
+)
+
 
 async def async_setup(hass, config):
     """Set up this component using YAML."""
+
+    async def handle_add_date(call):
+        """Handle the add_date service call."""
+        entity_id = call.data.get(CONF_ENTITY_ID)
+        dt = call.data.get(CONF_DATE)
+        _LOGGER.debug("called add_date %s to %s", dt, entity_id)
+        try:
+            entity = hass.data[DOMAIN][SENSOR_PLATFORM][entity_id]
+            _LOGGER.debug("date type is %s", type(dt))
+            # await entity.add_date(dt)
+        except Exception as err:
+            _LOGGER.error("Failed adding date for %s - %s", entity_id, err)
+
+    async def handle_remove_date(call):
+        """Handle the remove_date service call."""
+        entity_id = call.data.get(CONF_ENTITY_ID)
+        dt = call.data.get(CONF_DATE)
+        _LOGGER.debug("called remove_date %s to %s", dt, entity_id)
+        try:
+            entity = hass.data[DOMAIN][SENSOR_PLATFORM][entity_id]
+            _LOGGER.debug("date type is %s", type(dt))
+            # await entity.remove_date(dt)
+        except Exception as err:
+            _LOGGER.error("Failed removing date for %s - %s", entity_id, err)
 
     async def handle_update_state(call):
         """Handle the update_state service call."""
@@ -85,8 +117,14 @@ async def async_setup(hass, config):
         hass.services.async_register(
             DOMAIN, "update_state", handle_update_state, schema=UPDATE_STATE_SCHEMA
         )
+        hass.services.async_register(
+            DOMAIN, "add_date", handle_add_date, schema=ADD_REMOVE_DATE_SCHEMA
+        )
+        hass.services.async_register(
+            DOMAIN, "remove_date", handle_remove_date, schema=ADD_REMOVE_DATE_SCHEMA
+        )
     else:
-        _LOGGER.debug("Service already registered")
+        _LOGGER.debug("Services already registered")
 
     if config.get(DOMAIN) is None:
         # We get here if the integration is set up using config flow

--- a/custom_components/garbage_collection/calendar.py
+++ b/custom_components/garbage_collection/calendar.py
@@ -94,8 +94,7 @@ class EntitiesCalendarData:
             ):
                 continue
             garbage_collection = hass.data[DOMAIN][SENSOR_PLATFORM][entity]
-            await garbage_collection.async_load_holidays(start_date)
-            start = await garbage_collection.async_find_next_date(start_date, True)
+            start = await garbage_collection.async_next_date(start_date, True)
             while start is not None and start >= start_date and start <= end_date:
                 try:
                     end = start + timedelta(days=1)
@@ -126,7 +125,7 @@ class EntitiesCalendarData:
                         "allDay": False,
                     }
                 events.append(event)
-                start = await garbage_collection.async_find_next_date(
+                start = await garbage_collection.async_next_date(
                     start + timedelta(days=1), True
                 )
         return events

--- a/custom_components/garbage_collection/config_flow.py
+++ b/custom_components/garbage_collection/config_flow.py
@@ -108,7 +108,7 @@ class garbage_collection_shared:
             config_definition.reset_defaults()
             config_definition.set_defaults(1, defaults)
             config_definition.join_list(CONF_EXCLUDE_DATES)
-            config_definition.join_list(CONF_INCLUDE_DATES)            
+            config_definition.join_list(CONF_INCLUDE_DATES)
         self.data_schema = config_definition.compile_config_flow(step=1)
         # Do not show name for Options_Flow. The name cannot be changed here
         if defaults is not None and CONF_NAME in self.data_schema:

--- a/custom_components/garbage_collection/config_flow.py
+++ b/custom_components/garbage_collection/config_flow.py
@@ -107,6 +107,8 @@ class garbage_collection_shared:
         elif defaults is not None:
             config_definition.reset_defaults()
             config_definition.set_defaults(1, defaults)
+            config_definition.join_list(CONF_EXCLUDE_DATES)
+            config_definition.join_list(CONF_INCLUDE_DATES)            
         self.data_schema = config_definition.compile_config_flow(step=1)
         # Do not show name for Options_Flow. The name cannot be changed here
         if defaults is not None and CONF_NAME in self.data_schema:
@@ -239,6 +241,7 @@ class garbage_collection_shared:
                 return True
         elif defaults is not None:
             config_definition.set_defaults(4, defaults)
+            config_definition.join_list(CONF_HOLIDAY_POP_NAMED)
         self.data_schema = config_definition.compile_config_flow(
             step=4, valid_for=self._data[CONF_FREQUENCY]
         )

--- a/custom_components/garbage_collection/config_singularity.py
+++ b/custom_components/garbage_collection/config_singularity.py
@@ -109,3 +109,8 @@ class config_singularity:
                 type(data[key]) not in [list, dict] or len(data[key]) != 0
             ):
                 self._defaults[key] = data[key]
+
+    def join_list(self, key: str) -> None:
+        """Convert a list to comma separated string."""
+        if key in self._defaults and isinstance(self._defaults[key], list):
+            self._defaults[key] = ",".join(self._defaults[key])

--- a/custom_components/garbage_collection/const.py
+++ b/custom_components/garbage_collection/const.py
@@ -31,6 +31,7 @@ DEVICE_CLASS = "garbage_collection__schedule"
 CONF_SENSOR = "sensor"
 CONF_ENABLED = "enabled"
 CONF_FREQUENCY = "frequency"
+CONF_MANUAL = "manual_update"
 CONF_ICON_NORMAL = "icon_normal"
 CONF_ICON_TODAY = "icon_today"
 CONF_ICON_TOMORROW = "icon_tomorrow"
@@ -229,6 +230,13 @@ class configuration(config_singularity):
             "validator": cv.string,
         },
         ATTR_HIDDEN: {
+            "step": 1,
+            "method": vol.Optional,
+            "default": False,
+            "type": bool,
+            "validator": cv.boolean,
+        },
+        CONF_MANUAL: {
             "step": 1,
             "method": vol.Optional,
             "default": False,

--- a/custom_components/garbage_collection/manifest.json
+++ b/custom_components/garbage_collection/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "garbage_collection",
   "name": "Garbage Collection",
-  "version": "1.1",
+  "version": "3.21",
   "documentation": "https://github.com/bruxy70/Garbage-Collection/",
   "issue_tracker": "https://github.com/bruxy70/Garbage-Collection/issues",
   "iot_class": "calculated",

--- a/custom_components/garbage_collection/sensor.py
+++ b/custom_components/garbage_collection/sensor.py
@@ -713,14 +713,16 @@ class GarbageCollection(RestoreEntity):
         now = dt_util.now()
         today = now.date()
         await self._async_load_collection_dates()
-        _LOGGER.debug("(%s) Dates loaded, firing a garbage_collection_loaded event", self._name)
+        _LOGGER.debug(
+            "(%s) Dates loaded, firing a garbage_collection_loaded event", self._name
+        )
 
         """
         TO DO
         """
         event_data = {
             "entity_id": self.entity_id,
-            "collection_dates": dates_to_texts(self._collection_dates)
+            "collection_dates": dates_to_texts(self._collection_dates),
         }
         self.hass.bus.async_fire("garbage_collection_loaded", event_data)
         # self.hass.bus.fire("garbage_collection_loaded", event_data)

--- a/custom_components/garbage_collection/sensor.py
+++ b/custom_components/garbage_collection/sensor.py
@@ -653,7 +653,7 @@ class GarbageCollection(RestoreEntity):
         return next_date
 
     async def _async_load_collection_dates(self) -> None:
-        """Fill the collection dates list"""
+        """Fill the collection dates list."""
         today = dt_util.now().date()
         start_date = end_date = date(today.year - 1, 1, 1)
         end_date = date(today.year + 1, 12, 31)
@@ -674,8 +674,7 @@ class GarbageCollection(RestoreEntity):
     async def async_next_date(
         self, first_date: date, ignore_today=False
     ) -> Optional[date]:
-        """Get next date from self._collection_dates"""
-
+        """Get next date from self._collection_dates."""
         now = dt_util.now()
         for d in self._collection_dates:
             if d < first_date:
@@ -708,6 +707,11 @@ class GarbageCollection(RestoreEntity):
         """
         TO DO
         """
+        event_data = {
+            "device_id": self.entity_id,
+            "type": "dates_loaded",
+        }
+        self.hass.bus.async_fire("garbage_collection", event_data)
 
         _LOGGER.debug(
             "(%s) Event haldlers finished, looking for next collection", self._name

--- a/custom_components/garbage_collection/sensor.py
+++ b/custom_components/garbage_collection/sensor.py
@@ -255,8 +255,7 @@ class GarbageCollection(RestoreEntity):
                 for holiday_date, holiday_name in hol.items():
                     self._holidays.append(holiday_date)
                     log += f"\n  {holiday_date}: {holiday_name}"
-                    if holiday_date >= today and holiday_date <= year_from_today:
-                        self._holidays_log += f"\n  {holiday_date}: {holiday_name}"
+                    self._holidays_log += f"\n  {holiday_date}: {holiday_name}"
             except KeyError:
                 _LOGGER.error(
                     "(%s) Invalid country code (%s)",

--- a/custom_components/garbage_collection/sensor.py
+++ b/custom_components/garbage_collection/sensor.py
@@ -229,7 +229,7 @@ class GarbageCollection(RestoreEntity):
                 and type(self._holiday_observed) is bool
                 and not self._holiday_observed
             ):
-                kwargs["observed"] = self._holiday_observed
+                kwargs["observed"] = self._holiday_observed  # type: ignore
             hol = holidays.CountryHoliday(self._country_holidays, **kwargs)
             if self._holiday_pop_named is not None:
                 for pop in self._holiday_pop_named:

--- a/custom_components/garbage_collection/sensor.py
+++ b/custom_components/garbage_collection/sensor.py
@@ -685,7 +685,7 @@ class GarbageCollection(RestoreEntity):
         self._collection_dates.sort()
 
     async def add_date(self, collection_date: date) -> None:
-        """Add date to _collection_dates"""
+        """Add date to _collection_dates."""
         if collection_date not in self._collection_dates:
             self._collection_dates.append(collection_date)
             self._collection_dates.sort()
@@ -693,7 +693,7 @@ class GarbageCollection(RestoreEntity):
             raise KeyError(f"{collection_date} already on the collection schedule")
 
     async def remove_date(self, collection_date: date) -> None:
-        """Remove date from _collection dates"""
+        """Remove date from _collection dates."""
         self._collection_dates.remove(collection_date)
 
     async def async_next_date(

--- a/custom_components/garbage_collection/sensor.py
+++ b/custom_components/garbage_collection/sensor.py
@@ -219,7 +219,6 @@ class GarbageCollection(RestoreEntity):
         """Load the holidays from from a date."""
         self._holidays_log = ""
         log = ""
-        year_from_today = today + relativedelta(years=1)
         self._holidays.clear()
         if self._country_holidays is not None and self._country_holidays != "":
             this_year = today.year

--- a/custom_components/garbage_collection/sensor.py
+++ b/custom_components/garbage_collection/sensor.py
@@ -106,9 +106,9 @@ def to_date(day: Any) -> date:
     """Convert datetime or text to date, if not already datetime."""
     if day is None:
         raise ValueError
-    if type(day) == date:
+    if isinstance(day, date):
         return day
-    if type(day) == datetime:
+    if isinstance(day, datetime):
         return day.date()
     return date.fromisoformat(day)
 
@@ -240,7 +240,7 @@ class GarbageCollection(RestoreEntity):
                 kwargs["prov"] = self._holiday_prov
             if (
                 self._holiday_observed is not None
-                and type(self._holiday_observed) is bool
+                and isinstance(self._holiday_observed, bool)
                 and not self._holiday_observed
             ):
                 kwargs["observed"] = self._holiday_observed  # type: ignore
@@ -252,11 +252,11 @@ class GarbageCollection(RestoreEntity):
                     except Exception as err:
                         _LOGGER.error("(%s) Holiday not removed (%s)", self._name, err)
             try:
-                for d, name in hol.items():
-                    self._holidays.append(d)
-                    log += f"\n  {d}: {name}"
-                    if d >= today and d <= year_from_today:
-                        self._holidays_log += f"\n  {d}: {name}"
+                for holiday_date, holiday_name in hol.items():
+                    self._holidays.append(holiday_date)
+                    log += f"\n  {holiday_date}: {holiday_name}"
+                    if holiday_date >= today and holiday_date <= year_from_today:
+                        self._holidays_log += f"\n  {holiday_date}: {holiday_name}"
             except KeyError:
                 _LOGGER.error(
                     "(%s) Invalid country code (%s)",
@@ -589,11 +589,11 @@ class GarbageCollection(RestoreEntity):
             try:
                 if self._next_date == today and (
                     (
-                        type(self.expire_after) is time
+                        isinstance(self.expire_after, time)
                         and now.time() >= self.expire_after
                     )
                     or (
-                        type(self.last_collection) is datetime
+                        isinstance(self.last_collection, datetime)
                         and self.last_collection.date() == today
                     )
                 ):
@@ -683,6 +683,12 @@ class GarbageCollection(RestoreEntity):
             self._collection_dates.append(d)
             d = await self._async_find_next_date(d + timedelta(days=1))
         self._collection_dates.sort()
+
+    async def add_date(self, collection_date: date) -> None:
+        """Add date to _collection_dates"""
+
+    async def remove_date(self, collection_date: date) -> None:
+        """Remove date from _collection dates"""
 
     async def async_next_date(
         self, first_date: date, ignore_today=False

--- a/custom_components/garbage_collection/sensor.py
+++ b/custom_components/garbage_collection/sensor.py
@@ -686,9 +686,15 @@ class GarbageCollection(RestoreEntity):
 
     async def add_date(self, collection_date: date) -> None:
         """Add date to _collection_dates"""
+        if collection_date not in self._collection_dates:
+            self._collection_dates.append(collection_date)
+            self._collection_dates.sort()
+        else:
+            raise KeyError(f"{collection_date} already on the collection schedule")
 
     async def remove_date(self, collection_date: date) -> None:
         """Remove date from _collection dates"""
+        self._collection_dates.remove(collection_date)
 
     async def async_next_date(
         self, first_date: date, ignore_today=False

--- a/custom_components/garbage_collection/sensor.py
+++ b/custom_components/garbage_collection/sensor.py
@@ -139,6 +139,17 @@ def to_dates(dates: List[Any]) -> List[date]:
     return converted
 
 
+def dates_to_texts(dates: List[date]) -> List[str]:
+    """Convert list of dates to texts"""
+    converted = []  # type: List[str]
+    for day in dates:
+        try:
+            converted.append(day.isoformat())
+        except ValueError:
+            continue
+    return converted
+
+
 class GarbageCollection(RestoreEntity):
     """GarbageCollection Sensor class."""
 
@@ -702,16 +713,17 @@ class GarbageCollection(RestoreEntity):
         now = dt_util.now()
         today = now.date()
         await self._async_load_collection_dates()
-        _LOGGER.debug("(%s) Dates loaded, waiting for event handlers", self._name)
+        _LOGGER.debug("(%s) Dates loaded, firing a garbage_collection_loaded event", self._name)
 
         """
         TO DO
         """
         event_data = {
-            "device_id": self.entity_id,
-            "type": "dates_loaded",
+            "entity_id": self.entity_id,
+            "collection_dates": dates_to_texts(self._collection_dates)
         }
-        self.hass.bus.async_fire("garbage_collection", event_data)
+        self.hass.bus.async_fire("garbage_collection_loaded", event_data)
+        # self.hass.bus.fire("garbage_collection_loaded", event_data)
 
         _LOGGER.debug(
             "(%s) Event haldlers finished, looking for next collection", self._name

--- a/custom_components/garbage_collection/sensor.py
+++ b/custom_components/garbage_collection/sensor.py
@@ -141,7 +141,7 @@ def to_dates(dates: List[Any]) -> List[date]:
 
 
 def dates_to_texts(dates: List[date]) -> List[str]:
-    """Convert list of dates to texts"""
+    """Convert list of dates to texts."""
     converted = []  # type: List[str]
     for day in dates:
         try:

--- a/custom_components/garbage_collection/services.yaml
+++ b/custom_components/garbage_collection/services.yaml
@@ -7,4 +7,9 @@ collect_garbage:
     last_collection:
       description: Date and time of the last collection (optional)
       example: "2020-08-16 10:54:00"
-  
+update_state:
+  description: Update the entity state and attributes. Used with the manual_update option, do defer the update after changing the automatically created schedule by automation trigered by the garbage_collection_loaded event.
+  fields:
+    entity_id:
+      description: The garbage_collection sensor entity_id
+      example: sensor.general_waste

--- a/custom_components/garbage_collection/services.yaml
+++ b/custom_components/garbage_collection/services.yaml
@@ -1,5 +1,8 @@
 collect_garbage:
   description: Set the last_collection attribute to the current date and time.
+  target:
+    entity:
+      integration: garbage_collection
   fields:
     entity_id:
       description: The garbage_collection sensor entity_id
@@ -9,6 +12,9 @@ collect_garbage:
       example: "2020-08-16 10:54:00"
 add_date:
   description: Manually add collection date.
+  target:
+    entity:
+      integration: garbage_collection
   fields:
     entity_id:
       description: The garbage_collection sensor entity_id
@@ -18,6 +24,9 @@ add_date:
       example: "2020-08-16"
 remove_date:
   description: Remove automatically calculated collection date.
+  target:
+    entity:
+      integration: garbage_collection
   fields:
     entity_id:
       description: The garbage_collection sensor entity_id
@@ -27,6 +36,9 @@ remove_date:
       example: "2020-08-16"
 update_state:
   description: Update the entity state and attributes. Used with the manual_update option, do defer the update after changing the automatically created schedule by automation trigered by the garbage_collection_loaded event.
+  target:
+    entity:
+      integration: garbage_collection
   fields:
     entity_id:
       description: The garbage_collection sensor entity_id

--- a/custom_components/garbage_collection/services.yaml
+++ b/custom_components/garbage_collection/services.yaml
@@ -7,6 +7,24 @@ collect_garbage:
     last_collection:
       description: Date and time of the last collection (optional)
       example: "2020-08-16 10:54:00"
+add_date:
+  description: Manually add collection date.
+  fields:
+    entity_id:
+      description: The garbage_collection sensor entity_id
+      example: sensor.general_waste
+    date:
+      description: Collection date to add
+      example: "2020-08-16"
+remove_date:
+  description: Remove automatically calculated collection date.
+  fields:
+    entity_id:
+      description: The garbage_collection sensor entity_id
+      example: sensor.general_waste
+    date:
+      description: Collection date to remove
+      example: "2020-08-16"
 update_state:
   description: Update the entity state and attributes. Used with the manual_update option, do defer the update after changing the automatically created schedule by automation trigered by the garbage_collection_loaded event.
   fields:

--- a/custom_components/garbage_collection/services.yaml
+++ b/custom_components/garbage_collection/services.yaml
@@ -1,5 +1,8 @@
 collect_garbage:
   description: Set the last_collection attribute to the current date and time.
+  target:
+    entity:
+      integration: garbage_collection
   fields:
     entity_id:
       description: The garbage_collection sensor entity_id
@@ -9,24 +12,33 @@ collect_garbage:
       example: "2020-08-16 10:54:00"
 add_date:
   description: Manually add collection date.
+  target:
+    entity:
+      integration: garbage_collection
   fields:
     entity_id:
       description: The garbage_collection sensor entity_id
       example: sensor.general_waste
     date:
       description: Collection date to add
-      example: "2020-08-16"
+      example: '"2020-08-16"'
 remove_date:
   description: Remove automatically calculated collection date.
+  target:
+    entity:
+      integration: garbage_collection
   fields:
     entity_id:
       description: The garbage_collection sensor entity_id
       example: sensor.general_waste
     date:
       description: Collection date to remove
-      example: "2020-08-16"
+      example: '"2020-08-16"'
 update_state:
   description: Update the entity state and attributes. Used with the manual_update option, do defer the update after changing the automatically created schedule by automation trigered by the garbage_collection_loaded event.
+  target:
+    entity:
+      integration: garbage_collection
   fields:
     entity_id:
       description: The garbage_collection sensor entity_id

--- a/custom_components/garbage_collection/services.yaml
+++ b/custom_components/garbage_collection/services.yaml
@@ -1,8 +1,5 @@
 collect_garbage:
   description: Set the last_collection attribute to the current date and time.
-  target:
-    entity:
-      integration: garbage_collection
   fields:
     entity_id:
       description: The garbage_collection sensor entity_id
@@ -12,9 +9,6 @@ collect_garbage:
       example: "2020-08-16 10:54:00"
 add_date:
   description: Manually add collection date.
-  target:
-    entity:
-      integration: garbage_collection
   fields:
     entity_id:
       description: The garbage_collection sensor entity_id
@@ -24,9 +18,6 @@ add_date:
       example: "2020-08-16"
 remove_date:
   description: Remove automatically calculated collection date.
-  target:
-    entity:
-      integration: garbage_collection
   fields:
     entity_id:
       description: The garbage_collection sensor entity_id
@@ -36,9 +27,6 @@ remove_date:
       example: "2020-08-16"
 update_state:
   description: Update the entity state and attributes. Used with the manual_update option, do defer the update after changing the automatically created schedule by automation trigered by the garbage_collection_loaded event.
-  target:
-    entity:
-      integration: garbage_collection
   fields:
     entity_id:
       description: The garbage_collection sensor entity_id

--- a/custom_components/garbage_collection/services.yaml
+++ b/custom_components/garbage_collection/services.yaml
@@ -22,6 +22,21 @@ add_date:
     date:
       description: Collection date to add
       example: '"2020-08-16"'
+offset_date:
+  description: Move the collection date by a number of days.
+  target:
+    entity:
+      integration: garbage_collection
+  fields:
+    entity_id:
+      description: The garbage_collection sensor entity_id
+      example: sensor.general_waste
+    date:
+      description: Collection date to move
+      example: '"2020-08-16"'
+    offset:
+      description: Nuber of days to move (negative number will move it back)
+      example: 1
 remove_date:
   description: Remove automatically calculated collection date.
   target:

--- a/custom_components/garbage_collection/translations/cs.json
+++ b/custom_components/garbage_collection/translations/cs.json
@@ -8,7 +8,7 @@
                     "name": "Friendly name",
                     "hidden": "Skrýt v kalendáři",
                     "frequency": "Frekvence",
-                    "manual_update": "Sensor state aktualozvaný voláním služby",
+                    "manual_update": "State je aktualizovaný manuálně voláním služby",
                     "icon_normal": "Ikona (mdi:trash-can)",
                     "icon_tomorrow": "Ikona svoz zítra (mdi:delete-restore)",
                     "icon_today": "Ikona svoz dnes (mdi:delete-circle)",

--- a/custom_components/garbage_collection/translations/cs.json
+++ b/custom_components/garbage_collection/translations/cs.json
@@ -8,6 +8,7 @@
                     "name": "Friendly name",
                     "hidden": "Skrýt v kalendáři",
                     "frequency": "Frekvence",
+                    "manual_update": "Sensor state aktualozvaný voláním služby",
                     "icon_normal": "Ikona (mdi:trash-can)",
                     "icon_tomorrow": "Ikona svoz zítra (mdi:delete-restore)",
                     "icon_today": "Ikona svoz dnes (mdi:delete-circle)",

--- a/custom_components/garbage_collection/translations/cs.json
+++ b/custom_components/garbage_collection/translations/cs.json
@@ -98,6 +98,7 @@
                 "data": {
                     "hidden": "Skrýt v kalendáři",
                     "frequency": "Frekvence",
+                    "manual_update": "State je aktualizovaný manuálně voláním služby",
                     "icon_normal": "Ikona (mdi:trash-can)",
                     "icon_tomorrow": "Ikona svoz zítra (mdi:delete-restore)",
                     "icon_today": "Ikona svoz dnes (mdi:delete-circle)",

--- a/custom_components/garbage_collection/translations/en.json
+++ b/custom_components/garbage_collection/translations/en.json
@@ -7,6 +7,7 @@
                 "data": {
                     "name": "Friendly name",
                     "hidden": "Hide in calendar",
+                    "manual_update": "Sensor state updated only by calling service",
                     "frequency": "Frequency",
                     "icon_normal": "Icon (mdi:trash-can) - optional",
                     "icon_tomorrow": "Icon collection tomorrow (mdi:delete-restore) - optional",

--- a/custom_components/garbage_collection/translations/en.json
+++ b/custom_components/garbage_collection/translations/en.json
@@ -7,7 +7,7 @@
                 "data": {
                     "name": "Friendly name",
                     "hidden": "Hide in calendar",
-                    "manual_update": "Sensor state updated only by calling service",
+                    "manual_update": "Sensor state updated manually by calling a service",
                     "frequency": "Frequency",
                     "icon_normal": "Icon (mdi:trash-can) - optional",
                     "icon_tomorrow": "Icon collection tomorrow (mdi:delete-restore) - optional",

--- a/custom_components/garbage_collection/translations/en.json
+++ b/custom_components/garbage_collection/translations/en.json
@@ -7,8 +7,8 @@
                 "data": {
                     "name": "Friendly name",
                     "hidden": "Hide in calendar",
-                    "manual_update": "Sensor state updated manually by calling a service",
                     "frequency": "Frequency",
+                    "manual_update": "Sensor state updated manually by calling a service",
                     "icon_normal": "Icon (mdi:trash-can) - optional",
                     "icon_tomorrow": "Icon collection tomorrow (mdi:delete-restore) - optional",
                     "icon_today": "Icon collection today (mdi:delete-circle) - optional",
@@ -97,6 +97,7 @@
                 "data": {
                     "hidden": "Hide in calendar",
                     "frequency": "Frequency",
+                    "manual_update": "Sensor state updated manually by calling a service",
                     "icon_normal": "Icon (mdi:trash-can) - optional",
                     "icon_tomorrow": "Icon collection tomorrow (mdi:delete-restore) - optional",
                     "icon_today": "Icon collection today (mdi:delete-circle) - optional",

--- a/custom_components/garbage_collection/translations/es.json
+++ b/custom_components/garbage_collection/translations/es.json
@@ -8,7 +8,7 @@
                     "name": "Nombre amigable",
                     "hidden": "Esconderse en el calendario",
                     "frequency": "Frequencia",
-                    "manual_update": "Sensor state updated only by calling service",
+                    "manual_update": "El estado del sensor se actualiza manualmente llamando a un servicio",
                     "icon_normal": "Icono (mdi:trash-can)",
                     "icon_tomorrow": "Icono de recoleccion para mañana (mdi:delete-restore)",
                     "icon_today": "Icono de recoleccion para hoy (mdi:delete-circle)",

--- a/custom_components/garbage_collection/translations/es.json
+++ b/custom_components/garbage_collection/translations/es.json
@@ -97,6 +97,7 @@
                 "data": {
                     "hidden": "Esconderse en el calendario",
                     "frequency": "Frequencia",
+                    "manual_update": "El estado del sensor se actualiza manualmente llamando a un servicio",
                     "icon_normal": "Icono (mdi:trash-can)",
                     "icon_tomorrow": "Icono de recoleccion para mañana (mdi:delete-restore)",
                     "icon_today": "Icono de recoleccion para hoy (mdi:delete-circle)",

--- a/custom_components/garbage_collection/translations/es.json
+++ b/custom_components/garbage_collection/translations/es.json
@@ -8,6 +8,7 @@
                     "name": "Nombre amigable",
                     "hidden": "Esconderse en el calendario",
                     "frequency": "Frequencia",
+                    "manual_update": "Sensor state updated only by calling service",
                     "icon_normal": "Icono (mdi:trash-can)",
                     "icon_tomorrow": "Icono de recoleccion para mañana (mdi:delete-restore)",
                     "icon_today": "Icono de recoleccion para hoy (mdi:delete-circle)",

--- a/custom_components/garbage_collection/translations/et.json
+++ b/custom_components/garbage_collection/translations/et.json
@@ -8,7 +8,7 @@
                     "name": "Kuvatav nimi",
                     "hidden": "Ära näita kalendris",
                     "frequency": "Sagedus",
-                    "manual_update": "Sensor state updated only by calling service",
+                    "manual_update": "Sensor state updated manually by calling a service",
                     "icon_normal": "Ikoon (mdi:trash-can) - valikuline",
                     "icon_tomorrow": "Homme on prügivedu ikoon (mdi:delete-restore) - valikuline",
                     "icon_today": "Täna on prügivedu ikoon (mdi:delete-circle) - valikuline",

--- a/custom_components/garbage_collection/translations/et.json
+++ b/custom_components/garbage_collection/translations/et.json
@@ -98,6 +98,7 @@
                     "name": "Kuvatav nimi",
                     "hidden": "Ära näita kalendris",
                     "frequency": "Sagedus",
+                    "manual_update": "Sensor state updated manually by calling a service",
                     "icon_normal": "Ikoon (mdi:trash-can) - valikuline",
                     "icon_tomorrow": "Homme on prügivedu ikoon (mdi:delete-restore) - valikuline",
                     "icon_today": "Täna on prügivedu ikoon (mdi:delete-circle) - valikuline",

--- a/custom_components/garbage_collection/translations/et.json
+++ b/custom_components/garbage_collection/translations/et.json
@@ -8,6 +8,7 @@
                     "name": "Kuvatav nimi",
                     "hidden": "Ära näita kalendris",
                     "frequency": "Sagedus",
+                    "manual_update": "Sensor state updated only by calling service",
                     "icon_normal": "Ikoon (mdi:trash-can) - valikuline",
                     "icon_tomorrow": "Homme on prügivedu ikoon (mdi:delete-restore) - valikuline",
                     "icon_today": "Täna on prügivedu ikoon (mdi:delete-circle) - valikuline",

--- a/custom_components/garbage_collection/translations/fr.json
+++ b/custom_components/garbage_collection/translations/fr.json
@@ -8,6 +8,7 @@
                     "name": "Friendly name",
                     "hidden": "Masquer dans le calendrier",
                     "frequency": "Fréquence",
+                    "manual_update": "Sensor state updated only by calling service",
                     "icon_normal": "Icône (mdi:trash-can)",
                     "icon_tomorrow": "Icône pour collecte à jour J+1 (mdi:delete-restore)",
                     "icon_today": "Icône pour collecte au jour J (mdi:delete-circle)",

--- a/custom_components/garbage_collection/translations/fr.json
+++ b/custom_components/garbage_collection/translations/fr.json
@@ -92,8 +92,9 @@
                 "title": "Garbage Collection - Fréquence de la collecte",
                 "description": "Modifier les paramètres des capteurs. Plus d'infos sur https://github.com/bruxy70/Garbage-Collection",
                 "data": {
-                    "frequency": "Fréquence",
                     "hidden": "Masquer dans le calendrier",
+                    "frequency": "Fréquence",
+                    "manual_update": "État du capteur mis à jour manuellement en appelant un service",
                     "icon_normal": "Icône (mdi:trash-can)",
                     "icon_tomorrow": "Icône pour collecte à jour J+1 (mdi:delete-restore)",
                     "icon_today": "Icône pour collecte au jour J (mdi:delete-circle)",

--- a/custom_components/garbage_collection/translations/fr.json
+++ b/custom_components/garbage_collection/translations/fr.json
@@ -8,7 +8,7 @@
                     "name": "Friendly name",
                     "hidden": "Masquer dans le calendrier",
                     "frequency": "Fréquence",
-                    "manual_update": "Sensor state updated only by calling service",
+                    "manual_update": "État du capteur mis à jour manuellement en appelant un service",
                     "icon_normal": "Icône (mdi:trash-can)",
                     "icon_tomorrow": "Icône pour collecte à jour J+1 (mdi:delete-restore)",
                     "icon_today": "Icône pour collecte au jour J (mdi:delete-circle)",

--- a/custom_components/garbage_collection/translations/it.json
+++ b/custom_components/garbage_collection/translations/it.json
@@ -94,6 +94,7 @@
                 "data": {
                     "hidden": "Nascondi nel calendario",
                     "frequency": "Frequenza",
+                    "manual_update": "Stato del sensore aggiornato manualmente chiamando un servizio",
                     "icon_normal": "Icona (mdi:trash-can)",
                     "icon_tomorrow": "Icona raccolta domani (mdi:delete-restore)",
                     "icon_today": "Icona raccolta oggi (mdi:delete-circle)",

--- a/custom_components/garbage_collection/translations/it.json
+++ b/custom_components/garbage_collection/translations/it.json
@@ -8,7 +8,7 @@
                     "name": "Nome personalizzato",
                     "hidden": "Nascondi nel calendario",
                     "frequency": "Frequenza",
-                    "manual_update": "Sensor state updated only by calling service",
+                    "manual_update": "Stato del sensore aggiornato manualmente chiamando un servizio",
                     "icon_normal": "Icona (mdi:trash-can)",
                     "icon_tomorrow": "Icona raccolta domani (mdi:delete-restore)",
                     "icon_today": "Icona raccolta oggi (mdi:delete-circle)",

--- a/custom_components/garbage_collection/translations/it.json
+++ b/custom_components/garbage_collection/translations/it.json
@@ -8,6 +8,7 @@
                     "name": "Nome personalizzato",
                     "hidden": "Nascondi nel calendario",
                     "frequency": "Frequenza",
+                    "manual_update": "Sensor state updated only by calling service",
                     "icon_normal": "Icona (mdi:trash-can)",
                     "icon_tomorrow": "Icona raccolta domani (mdi:delete-restore)",
                     "icon_today": "Icona raccolta oggi (mdi:delete-circle)",

--- a/custom_components/garbage_collection/translations/pl.json
+++ b/custom_components/garbage_collection/translations/pl.json
@@ -8,6 +8,7 @@
                     "name": "Przyjazna nazwa",
                     "hidden": "Ukryj w kalendarzu",
                     "frequency": "Częstotliwość",
+                    "manual_update": "Sensor state updated only by calling service",
                     "icon_normal": "Ikona (mdi:trash-can) - opcjonalnie",
                     "icon_tomorrow": "Ikona wywozu jutro (mdi:delete-restore) - opcjonalnie",
                     "icon_today": "Ikona wywozu dzisiaj (mdi:delete-circle)- opcjonalnie",

--- a/custom_components/garbage_collection/translations/pl.json
+++ b/custom_components/garbage_collection/translations/pl.json
@@ -8,7 +8,7 @@
                     "name": "Przyjazna nazwa",
                     "hidden": "Ukryj w kalendarzu",
                     "frequency": "Częstotliwość",
-                    "manual_update": "Sensor state updated only by calling service",
+                    "manual_update": "Stan czujnika aktualizowany ręcznie poprzez wywołanie usługi",
                     "icon_normal": "Ikona (mdi:trash-can) - opcjonalnie",
                     "icon_tomorrow": "Ikona wywozu jutro (mdi:delete-restore) - opcjonalnie",
                     "icon_today": "Ikona wywozu dzisiaj (mdi:delete-circle)- opcjonalnie",

--- a/custom_components/garbage_collection/translations/pl.json
+++ b/custom_components/garbage_collection/translations/pl.json
@@ -97,6 +97,7 @@
                 "data": {
                     "hidden": "Ukryj w kalendarzu",
                     "frequency": "Częstotliwość",
+                    "manual_update": "Stan czujnika aktualizowany ręcznie poprzez wywołanie usługi",
                     "icon_normal": "Ikona (mdi:trash-can) - opcjonalnie",
                     "icon_tomorrow": "Ikona wywozu jutro (mdi:delete-restore) - opcjonalnie",
                     "icon_today": "Ikona wywozu dzisiaj (mdi:delete-circle)- opcjonalnie",

--- a/info.md
+++ b/info.md
@@ -46,7 +46,7 @@ garbage_collection:
     frequency: 'annual'
     date: '11/24'
 ```
-For more examples and configuration documentation check the <a href="https://github.com/bruxy70/Garbage-Collection">repository</a> file
+For more examples and configuration documentation check the <a href="https://github.com/bruxy70/Garbage-Collection/blob/development/README.md">repository</a> file
 
 ## STATE AND ATTRIBUTES
 
@@ -76,6 +76,6 @@ It will set the `last_collection` attribute to the current date and time.
 
 | Attribute | Description
 |:----------|------------
-| `entity_id` | The gatbage collection entity id (e.g. `sensor.general_waste`)
+| `entity_id` | The garbage collection entity id (e.g. `sensor.general_waste`)
 
-For more details see the <a href="https://github.com/bruxy70/Garbage-Collection">repository.</a>
+For more details see the <a href="https://github.com/bruxy70/Garbage-Collection/blob/development/README.md">repository.</a>

--- a/info.md
+++ b/info.md
@@ -1,4 +1,4 @@
-[![hacs_badge](https://img.shields.io/badge/HACS-Default-orange.svg)](https://github.com/custom-components/hacs) [![Garbage-Collection](https://img.shields.io/github/v/release/bruxy70/Garbage-Collection.svg?1)](https://github.com/bruxy70/Garbage-Collection) ![Maintenance](https://img.shields.io/maintenance/yes/2021.svg)
+[![hacs_badge](https://img.shields.io/badge/HACS-Default-orange.svg)](https://github.com/custom-components/hacs) [![Garbage-Collection](https://img.shields.io/github/v/release/bruxy70/Garbage-Collection.svg?1)](https://github.com/bruxy70/Garbage-Collection) ![Maintenance](https://img.shields.io/maintenance/yes/2022.svg)
 
 [![Buy me a coffee](https://img.shields.io/static/v1.svg?label=Buy%20me%20a%20coffee&message=🥨&color=black&logo=buy%20me%20a%20coffee&logoColor=white&labelColor=6f4e37)](https://www.buymeacoffee.com/3nXx0bJDP)
 
@@ -77,3 +77,5 @@ It will set the `last_collection` attribute to the current date and time.
 | Attribute | Description
 |:----------|------------
 | `entity_id` | The gatbage collection entity id (e.g. `sensor.general_waste`)
+
+For more details see the <a href="https://github.com/bruxy70/Garbage-Collection">repository.</a>


### PR DESCRIPTION
The integration now allows configuring parameter `manual_update: true`. Then, after calculating the collection schedule, it will not automatically update the entity state. Instead, it will fire an event `garbage_collection_loaded`, which will allow you to programmatically add and/or remove dates based on whatever custom logic (e.g. based on values from external API sensor, comparing the dates with a list of holidays, calculating custom offsets based on the day of the week etc.), and then manually trigger the update of the entity state and attributes by calling the service `garbage_collection.update_state`. 

This is the result of refactoring described in #287. There were a number of feature-request for very specific custom collection schedules, that should be now doable with this. 