### PR TITLE
Use standard attributes. Remove unused import. Remove platform set-up for calendar

### DIFF
--- a/Garbage Collection.code-workspace
+++ b/Garbage Collection.code-workspace
@@ -5,7 +5,6 @@
 		}
 	],
 	"settings": {
-		"python.analysis.typeCheckingMode": "basic",
 		"files.associations": {
 			"*.yaml": "home-assistant"
 		}

--- a/custom_components/garbage_collection/__init__.py
+++ b/custom_components/garbage_collection/__init__.py
@@ -14,6 +14,7 @@ from dateutil.relativedelta import relativedelta
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_HIDDEN, CONF_ENTITIES, CONF_ENTITY_ID, WEEKDAYS
 from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.helpers.typing import ConfigType
 
 from . import const, helpers
 
@@ -97,7 +98,7 @@ OFFSET_DATE_SCHEMA = vol.Schema(
 )
 
 
-async def async_setup(hass: HomeAssistant, _) -> bool:
+async def async_setup(hass: HomeAssistant, _: ConfigType) -> bool:
     """Set up this component using YAML."""
 
     async def handle_add_date(call: ServiceCall) -> None:
@@ -184,31 +185,32 @@ async def async_setup(hass: HomeAssistant, _) -> bool:
                     "Failed setting last collection for %s - %s", entity_id, err
                 )
 
-    if const.DOMAIN not in hass.services.async_services():
-        hass.services.async_register(
-            const.DOMAIN,
-            "collect_garbage",
-            handle_collect_garbage,
-            schema=COLLECT_NOW_SCHEMA,
-        )
-        hass.services.async_register(
-            const.DOMAIN,
-            "update_state",
-            handle_update_state,
-            schema=UPDATE_STATE_SCHEMA,
-        )
-        hass.services.async_register(
-            const.DOMAIN, "add_date", handle_add_date, schema=ADD_REMOVE_DATE_SCHEMA
-        )
-        hass.services.async_register(
-            const.DOMAIN,
-            "remove_date",
-            handle_remove_date,
-            schema=ADD_REMOVE_DATE_SCHEMA,
-        )
-        hass.services.async_register(
-            const.DOMAIN, "offset_date", handle_offset_date, schema=OFFSET_DATE_SCHEMA
-        )
+    hass.data.setdefault(const.DOMAIN, {})
+    hass.data[const.DOMAIN].setdefault(const.SENSOR_PLATFORM, {})
+    hass.services.async_register(
+        const.DOMAIN,
+        "collect_garbage",
+        handle_collect_garbage,
+        schema=COLLECT_NOW_SCHEMA,
+    )
+    hass.services.async_register(
+        const.DOMAIN,
+        "update_state",
+        handle_update_state,
+        schema=UPDATE_STATE_SCHEMA,
+    )
+    hass.services.async_register(
+        const.DOMAIN, "add_date", handle_add_date, schema=ADD_REMOVE_DATE_SCHEMA
+    )
+    hass.services.async_register(
+        const.DOMAIN,
+        "remove_date",
+        handle_remove_date,
+        schema=ADD_REMOVE_DATE_SCHEMA,
+    )
+    hass.services.async_register(
+        const.DOMAIN, "offset_date", handle_offset_date, schema=OFFSET_DATE_SCHEMA
+    )
     return True
 
 
@@ -242,7 +244,7 @@ async def async_remove_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> 
         pass
 
 
-async def async_migrate_entry(_, config_entry: ConfigEntry) -> bool:
+async def async_migrate_entry(_: HomeAssistant, config_entry: ConfigEntry) -> bool:
     """Migrate old entry."""
     _LOGGER.info(
         "Migrating %s from version %s", config_entry.title, config_entry.version

--- a/custom_components/garbage_collection/__init__.py
+++ b/custom_components/garbage_collection/__init__.py
@@ -363,6 +363,10 @@ async def async_migrate_entry(_: HomeAssistant, config_entry: ConfigEntry) -> bo
 
 async def update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Update listener - to re-create device after options update."""
+    for entity in hass.data["garbage_collection"]["sensor"].values():
+        if entity.unique_id == entry.entry_id:
+            entity.clear_state()
+            break
     await hass.config_entries.async_forward_entry_unload(entry, const.SENSOR_PLATFORM)
     hass.async_add_job(
         hass.config_entries.async_forward_entry_setup(entry, const.SENSOR_PLATFORM)

--- a/custom_components/garbage_collection/__init__.py
+++ b/custom_components/garbage_collection/__init__.py
@@ -363,10 +363,6 @@ async def async_migrate_entry(_: HomeAssistant, config_entry: ConfigEntry) -> bo
 
 async def update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Update listener - to re-create device after options update."""
-    for entity in hass.data["garbage_collection"]["sensor"].values():
-        if entity.unique_id == entry.entry_id:
-            entity.clear_state()
-            break
     await hass.config_entries.async_forward_entry_unload(entry, const.SENSOR_PLATFORM)
     hass.async_add_job(
         hass.config_entries.async_forward_entry_setup(entry, const.SENSOR_PLATFORM)

--- a/custom_components/garbage_collection/calendar.py
+++ b/custom_components/garbage_collection/calendar.py
@@ -18,7 +18,7 @@ async def async_setup_entry(
     _: HomeAssistant, config_entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
     # pylint: disable=unused-argument
-    """Add calendar entity to HA"""
+    """Add calendar entity to HA."""
     async_add_entities([GarbageCollectionCalendar()], True)
 
 

--- a/custom_components/garbage_collection/calendar.py
+++ b/custom_components/garbage_collection/calendar.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 from datetime import datetime, timedelta
 
 from homeassistant.components.calendar import CalendarEntity, CalendarEvent
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.util import Throttle
 
 from .const import CALENDAR_NAME, CALENDAR_PLATFORM, DOMAIN, SENSOR_PLATFORM
@@ -12,14 +14,12 @@ from .const import CALENDAR_NAME, CALENDAR_PLATFORM, DOMAIN, SENSOR_PLATFORM
 MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=1)
 
 
-async def async_setup_platform(
-    hass, config, async_add_entities, discovery_info=None
+async def async_setup_entry(
+    _: HomeAssistant, config_entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
-    """Add calendar entities to HA, of there are calendar instances."""
     # pylint: disable=unused-argument
-    # Only single instance allowed
-    if not GarbageCollectionCalendar.instances:
-        async_add_entities([GarbageCollectionCalendar()], True)
+    """Add calendar entity to HA"""
+    async_add_entities([GarbageCollectionCalendar()], True)
 
 
 class GarbageCollectionCalendar(CalendarEntity):

--- a/custom_components/garbage_collection/config_flow.py
+++ b/custom_components/garbage_collection/config_flow.py
@@ -10,7 +10,7 @@ from typing import Any, Dict, cast
 import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
 from homeassistant.const import ATTR_HIDDEN, CONF_ENTITIES, CONF_NAME, WEEKDAYS
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import callback
 from homeassistant.helpers import selector
 from homeassistant.helpers.schema_config_entry_flow import (
     SchemaConfigFlowHandler,

--- a/custom_components/garbage_collection/config_flow.py
+++ b/custom_components/garbage_collection/config_flow.py
@@ -62,7 +62,7 @@ def optional(
 
 
 def general_options_schema(
-    _,
+    _: SchemaConfigFlowHandler | SchemaOptionsFlowHandler,
     options: Dict[str, Any],
 ) -> vol.Schema:
     """Generate options schema."""

--- a/custom_components/garbage_collection/config_flow.py
+++ b/custom_components/garbage_collection/config_flow.py
@@ -10,7 +10,7 @@ from typing import Any, Dict, cast
 import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
 from homeassistant.const import ATTR_HIDDEN, CONF_ENTITIES, CONF_NAME, WEEKDAYS
-from homeassistant.core import callback
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import selector
 from homeassistant.helpers.schema_config_entry_flow import (
     SchemaConfigFlowHandler,
@@ -183,8 +183,8 @@ OPTIONS_FLOW: Dict[str, SchemaFlowFormStep | SchemaFlowMenuStep] = {
 
 
 # mypy: ignore-errors
-class HolidaysConfigFlowHandler(SchemaConfigFlowHandler, domain=const.DOMAIN):
-    """Handle a config or options flow for Holdays."""
+class GarbageCollectionConfigFlowHandler(SchemaConfigFlowHandler, domain=const.DOMAIN):
+    """Handle a config or options flow for GarbageCollection."""
 
     config_flow = CONFIG_FLOW
     options_flow = OPTIONS_FLOW

--- a/custom_components/garbage_collection/sensor.py
+++ b/custom_components/garbage_collection/sensor.py
@@ -170,6 +170,12 @@ class GarbageCollection(RestoreEntity):
                 self.entity_id
             )
 
+    def clear_state(self) -> None:
+        """Erase the stored state (called when configuration change)."""
+        self._attr_state = ""
+        self._days = None
+        self._next_date = None
+
     async def async_will_remove_from_hass(self) -> None:
         """When sensor is added to hassio, remove it."""
         await super().async_will_remove_from_hass()

--- a/custom_components/garbage_collection/sensor.py
+++ b/custom_components/garbage_collection/sensor.py
@@ -228,19 +228,19 @@ class GarbageCollection(RestoreEntity):
     @property
     def extra_state_attributes(self):
         """Return the state attributes."""
-        res = {}
-        if self._next_date is None:
-            res[const.ATTR_NEXT_DATE] = None
-        else:
-            res[const.ATTR_NEXT_DATE] = datetime(
+        state_attr = {
+            const.ATTR_DAYS: self._days,
+            const.ATTR_LAST_COLLECTION: self.last_collection,
+            const.ATTR_LAST_UPDATED: self._last_updated,
+            const.ATTR_NEXT_DATE: None
+            if self._next_date is not None
+            else datetime(
                 self._next_date.year, self._next_date.month, self._next_date.day
-            ).astimezone()
-        res[const.ATTR_DAYS] = self._days
-        res[const.ATTR_LAST_COLLECTION] = self.last_collection
-        res[const.ATTR_LAST_UPDATED] = self._last_updated
-        # Needed for translations to work
-        res[ATTR_DEVICE_CLASS] = self.DEVICE_CLASS
-        return res
+            ).astimezone(),
+            # Needed for translations to work
+            ATTR_DEVICE_CLASS: self.DEVICE_CLASS,
+        }
+        return state_attr
 
     @property
     def DEVICE_CLASS(self):  # pylint: disable=C0103

--- a/custom_components/garbage_collection/sensor.py
+++ b/custom_components/garbage_collection/sensor.py
@@ -206,7 +206,12 @@ class GarbageCollection(RestoreEntity):
         return self._hidden
 
     @property
-    def state(self):
+    def native_unit_of_measurement(self):
+        """Return unit of measurement - None for numerical value."""
+        return None
+
+    @property
+    def native_value(self):
         """Return the state of the sensor."""
         return self._attr_state
 

--- a/custom_components/garbage_collection/sensor.py
+++ b/custom_components/garbage_collection/sensor.py
@@ -138,10 +138,11 @@ class GarbageCollection(RestoreEntity):
 
         # Restore stored state
         if (state := await self.async_get_last_state()) is not None:
-            self._attr_state = state.state
-            self._days = state.attributes[const.ATTR_DAYS]
-            next_date = helpers.parse_datetime(state.attributes[const.ATTR_NEXT_DATE])
-            self._next_date = None if next_date is None else next_date.date()
+            # TBD - This will prevent update when options change
+            # self._attr_state = state.state
+            # self._days = state.attributes[const.ATTR_DAYS]
+            # next_date = helpers.parse_datetime(state.attributes[const.ATTR_NEXT_DATE])
+            # self._next_date = None if next_date is None else next_date.date()
             self.last_collection = helpers.parse_datetime(
                 state.attributes[const.ATTR_LAST_COLLECTION]
             )

--- a/custom_components/garbage_collection/sensor.py
+++ b/custom_components/garbage_collection/sensor.py
@@ -110,7 +110,12 @@ class GarbageCollection(RestoreEntity):
         self._icon_tomorrow = config.get(const.CONF_ICON_TOMORROW)
         exp = config.get(const.CONF_EXPIRE_AFTER)
         self.expire_after: time | None = (
-            None if exp is None else datetime.strptime(exp, "%H:%M:%S").time()
+            None
+            if (
+                exp is None
+                or datetime.strptime(exp, "%H:%M:%S").time() == time(0, 0, 0)
+            )
+            else datetime.strptime(exp, "%H:%M:%S").time()
         )
         self._date_format = config.get(
             const.CONF_DATE_FORMAT, const.DEFAULT_DATE_FORMAT
@@ -135,9 +140,8 @@ class GarbageCollection(RestoreEntity):
         if (state := await self.async_get_last_state()) is not None:
             self._attr_state = state.state
             self._days = state.attributes[const.ATTR_DAYS]
-            self._next_date = helpers.parse_datetime(
-                state.attributes[const.ATTR_NEXT_DATE]
-            )
+            next_date = helpers.parse_datetime(state.attributes[const.ATTR_NEXT_DATE])
+            self._next_date = None if next_date is None else next_date.date()
             self.last_collection = helpers.parse_datetime(
                 state.attributes[const.ATTR_LAST_COLLECTION]
             )

--- a/custom_components/garbage_collection/sensor.py
+++ b/custom_components/garbage_collection/sensor.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import logging
 from datetime import date, datetime, time, timedelta
-from typing import Generator
+from typing import Any, Dict, Generator
 
 from dateutil.relativedelta import relativedelta
 from homeassistant.config_entries import ConfigEntry
@@ -126,7 +126,7 @@ class GarbageCollection(RestoreEntity):
         self._attr_state = "" if bool(self._verbose_state) else 2
         self._attr_icon = self._icon_normal
 
-    async def async_added_to_hass(self):
+    async def async_added_to_hass(self) -> None:
         """When sensor is added to hassio, add it to calendar."""
         await super().async_added_to_hass()
         self.hass.data[const.DOMAIN][const.SENSOR_PLATFORM][self.entity_id] = self
@@ -166,7 +166,7 @@ class GarbageCollection(RestoreEntity):
                 self.entity_id
             )
 
-    async def async_will_remove_from_hass(self):
+    async def async_will_remove_from_hass(self) -> None:
         """When sensor is added to hassio, remove it."""
         await super().async_will_remove_from_hass()
         del self.hass.data[const.DOMAIN][const.SENSOR_PLATFORM][self.entity_id]
@@ -182,7 +182,7 @@ class GarbageCollection(RestoreEntity):
         return self.config_entry.entry_id
 
     @property
-    def device_info(self):
+    def device_info(self) -> Dict[str, Any]:
         """Return device info."""
         return {
             "identifiers": {(const.DOMAIN, self.unique_id)},
@@ -196,37 +196,37 @@ class GarbageCollection(RestoreEntity):
         return self._attr_name
 
     @property
-    def next_date(self):
+    def next_date(self) -> date | None:
         """Return next date attribute."""
         return self._next_date
 
     @property
-    def hidden(self):
+    def hidden(self) -> bool:
         """Return the hidden attribute."""
         return self._hidden
 
     @property
-    def native_unit_of_measurement(self):
+    def native_unit_of_measurement(self) -> str | None:
         """Return unit of measurement - None for numerical value."""
         return None
 
     @property
-    def native_value(self):
+    def native_value(self) -> object:
         """Return the state of the sensor."""
         return self._attr_state
 
     @property
-    def last_updated(self):
+    def last_updated(self) -> datetime | None:
         """Return when the sensor was last updated."""
         return self._last_updated
 
     @property
-    def icon(self):
+    def icon(self) -> str:
         """Return the entity icon."""
         return self._attr_icon
 
     @property
-    def extra_state_attributes(self):
+    def extra_state_attributes(self) -> Dict[str, Any]:
         """Return the state attributes."""
         state_attr = {
             const.ATTR_DAYS: self._days,
@@ -243,11 +243,11 @@ class GarbageCollection(RestoreEntity):
         return state_attr
 
     @property
-    def DEVICE_CLASS(self):  # pylint: disable=C0103
+    def DEVICE_CLASS(self) -> str:  # pylint: disable=C0103
         """Return the class of the sensor."""
         return const.DEVICE_CLASS
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """Return main sensor parameters."""
         return (
             f"{self.__class__.__name__}(name={self._attr_name}, "

--- a/custom_components/garbage_collection/sensor.py
+++ b/custom_components/garbage_collection/sensor.py
@@ -233,7 +233,7 @@ class GarbageCollection(RestoreEntity):
             const.ATTR_LAST_COLLECTION: self.last_collection,
             const.ATTR_LAST_UPDATED: self._last_updated,
             const.ATTR_NEXT_DATE: None
-            if self._next_date is not None
+            if self._next_date is None
             else datetime(
                 self._next_date.year, self._next_date.month, self._next_date.day
             ).astimezone(),

--- a/test/test_calendar.py
+++ b/test/test_calendar.py
@@ -2,6 +2,7 @@
 
 from datetime import datetime
 
+from homeassistant import config_entries
 from homeassistant.core import HomeAssistant
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
@@ -20,14 +21,10 @@ async def test_calendar(hass: HomeAssistant) -> None:
     config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
+    assert config_entry.state == config_entries.ConfigEntryState.LOADED
     calendar = hass.states.get("calendar.garbage_collection")
     assert calendar is not None
-    assert calendar.attributes["message"] == "calendar"
     assert calendar.state == "off"
-    start_time = calendar.attributes["start_time"]
-    end_time = calendar.attributes["end_time"]
-    assert start_time == "2020-04-06 00:00:00"
-    assert end_time == "2020-04-07 00:00:00"
     start_date = datetime(2020, 4, 1)
     end_date = datetime(2020, 5, 1)
     events = await hass.data["garbage_collection"]["calendar"].async_get_events(


### PR DESCRIPTION
Following HA strategy - changing state parameters, Unit of Measurement. Removing Platform setup for Calendar.
Attempt to extend restore state to more attributes failed - preventing updating state after options change - to be addressed later.
Also wanted to add standard naming, but looks like it is not applicable to this integration.
Minor updates (typing)